### PR TITLE
Apple TV-style restyle: white focus glow + spring lift, darker panels

### DIFF
--- a/colors/defaults.xml
+++ b/colors/defaults.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <colors>
-	<color name="primary_background">FF303232</color>
+	<color name="primary_background">FF1C1C1E</color>
 	<color name="dialog_tint">FF050505</color>
 	<color name="dialog_bg">BF050505</color>
 	<color name="dialog_bg2">F2050505</color>
 	<color name="dialog_bg3">F7050505</color>
-	<color name="button_focus">FFCCCCCC</color>
+	<color name="button_focus">FFFFFFFF</color>
 	<color name="button_focus2">FF040505</color>
 	<color name="focused_text">FF141515</color>
 	<!-- <color name="unfocused_text">FFC1C1C1</color> -->
 	<!-- <color name="unfocused_text">FFCCCCCC</color> -->
 	<color name="unfocused_text">FFE0E0E8</color>
 	<color name="artwork_dim">FFE9E9E9</color>
-	<color name="accent_color">FFCCCCCC</color>
+	<color name="accent_color">FFF2F2F7</color>
 	<color name="selected">FF1773CD</color>
 	<color name="keyboard_selected">FF1773CD</color>
 	<color name="primary_content_panel_bg">FF354CCF</color>

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -1919,6 +1919,10 @@
 					<texture colordiffuse="$VAR[FocusColorTheme]">masks/landscape-glow.png</texture>
 					<bordersize>-25</bordersize>
 					<include>Animation_FocusTextureFade</include>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="205.5"/>
+						<param name="pos_y" value="135.5"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="205.5"/>
 						<param name="pos_y" value="135.5"/>

--- a/xml/Includes_Animations.xml
+++ b/xml/Includes_Animations.xml
@@ -5,6 +5,15 @@
 		<animation effect="fade" start="100" end="0" time="0">UnFocus</animation>
 	</include>
 
+	<!-- Apple TV-style focus "lift": the focus glow pops in with a soft spring
+	     overshoot instead of just appearing. Settles back to its normal
+	     100% size, so it never persists larger than before and can't
+	     overlap neighbouring items - only the transition itself grows. -->
+	<include name="Animation_FocusGlowLift">
+		<animation effect="zoom" start="88" end="100" center="$PARAM[pos_x],$PARAM[pos_y]" time="260" tween="back" easing="out">Focus</animation>
+		<animation effect="zoom" start="100" end="88" center="$PARAM[pos_x],$PARAM[pos_y]" time="140" tween="cubic" easing="in">UnFocus</animation>
+	</include>
+
 	<include name="Animation_DialogPopupOpenClose">
 		<animation type="WindowOpen" reversible="false">
 			<effect type="zoom" start="80" end="100" center="50%,50%" delay="160" tween="back" time="240" />

--- a/xml/Includes_HomeLayouts.xml
+++ b/xml/Includes_HomeLayouts.xml
@@ -19,6 +19,10 @@
 						<visible>$PARAM[focused] + Control.HasFocus($PARAM[list_id])</visible>
 						<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
 					</control>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="117.5"/>
+						<param name="pos_y" value="117.5"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="117.5"/>
 						<param name="pos_y" value="117.5"/>
@@ -109,6 +113,10 @@
 						<visible>$PARAM[focused] + Control.HasFocus($PARAM[list_id])</visible>
 						<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
 					</control>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="217"/>
+						<param name="pos_y" value="150"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="217"/>
 						<param name="pos_y" value="150"/>
@@ -246,6 +254,10 @@
 						<visible>$PARAM[focused] + Control.HasFocus($PARAM[list_id])</visible>
 						<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
 					</control>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="117.5"/>
+						<param name="pos_y" value="117.5"/>
+					</include>
 					<include content="GlowPulse">
             <param name="pos_x" value="117.5"/>
 						<param name="pos_y" value="117.5"/>
@@ -387,6 +399,10 @@
 					<visible>[$PARAM[focused] + Control.HasFocus($PARAM[list_id])] | [$PARAM[focused] + [Control.IsVisible(54) | Control.IsVisible(500)]]</visible>
 					<!-- <visible>!Container($PARAM[list_id]).IsUpdating</visible> -->
 					<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="100.5"/>
+						<param name="pos_y" value="150.5"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="100.5"/>
 						<param name="pos_y" value="150.5"/>
@@ -585,6 +601,10 @@
 					<visible>[$PARAM[focused] + Control.HasFocus($PARAM[list_id])] | [$PARAM[focused] + [Control.IsVisible(55) | Control.IsVisible(501)]]</visible>
 					<!-- <visible>!Container($PARAM[list_id]).IsUpdating</visible> -->
 					<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="215"/>
+						<param name="pos_y" value="121"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="215"/>
 						<param name="pos_y" value="121"/>

--- a/xml/View_52_IconWall.xml
+++ b/xml/View_52_IconWall.xml
@@ -88,6 +88,10 @@
 							<height>211</height>
 							<texture colordiffuse="$VAR[FocusColorTheme]">masks/landscape-glow.png</texture>
 							<bordersize>-23</bordersize>
+							<include content="Animation_FocusGlowLift">
+								<param name="pos_x" value="199.5"/>
+								<param name="pos_y" value="122.5"/>
+							</include>
 							<include content="GlowPulse">
 								<param name="pos_x" value="199.5"/>
 								<param name="pos_y" value="122.5"/>

--- a/xml/View_54_Flix.xml
+++ b/xml/View_54_Flix.xml
@@ -63,6 +63,10 @@
 						<visible>[$PARAM[focused] + Control.HasFocus($PARAM[list_id])] | [$PARAM[focused] + ControlGroup(400).HasFocus]</visible>
 						<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
 					</control>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="117.5"/>
+						<param name="pos_y" value="117.5"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="117.5"/>
 						<param name="pos_y" value="117.5"/>
@@ -220,6 +224,10 @@
 					<visible>[$PARAM[focused] + Control.HasFocus($PARAM[list_id])] | [$PARAM[focused] + [Control.IsVisible(54) | Control.IsVisible(500)]]</visible>
 					<!-- <visible>!Container($PARAM[list_id]).IsUpdating</visible> -->
 					<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="133.5"/>
+						<param name="pos_y" value="193.5"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="133.5"/>
 						<param name="pos_y" value="193.5"/>

--- a/xml/View_55_FlixScape.xml
+++ b/xml/View_55_FlixScape.xml
@@ -78,6 +78,10 @@
 					<visible>[$PARAM[focused] + Control.HasFocus($PARAM[list_id])] | [$PARAM[focused] + [Control.IsVisible(55) | Control.IsVisible(501)]]</visible>
 					<!-- <visible>!Container($PARAM[list_id]).IsUpdating</visible> -->
 					<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
+					<include content="Animation_FocusGlowLift">
+						<param name="pos_x" value="307.5"/>
+						<param name="pos_y" value="176"/>
+					</include>
 					<include content="GlowPulse">
 						<param name="pos_x" value="307.5"/>
 						<param name="pos_y" value="176"/>


### PR DESCRIPTION
Visual restyle only, no layout/navigation changes:

- colors/defaults.xml: focus glow/highlight color (button_focus) shifted from light grey to a crisp white, accent_color to a soft near-white ("Apple silver"), and primary_background darkened to a neutral near- black (matches tvOS's system dark gray) instead of the previous warmer dark grey. Nimbus's background was already true black, and dialog panels were already near-black translucent, so those are unchanged.
- New shared animation "Animation_FocusGlowLift" (Includes_Animations.xml): the existing per-item focus glow now pops in with a soft spring overshoot (88% -> 100% with "back" easing) instead of just fading in, giving the tvOS "lift" feel. It settles back to the exact same static size as before on completion, so there's no persistent size change and therefore no new risk of overlapping neighbouring items - only the transition itself grows. Wired into all 10 existing focus-glow controls (posters, landscape tiles, PVR tiles, addon icons, FlixScape cards) across Includes.xml, Includes_HomeLayouts.xml, View_52_IconWall.xml, View_54_Flix.xml and View_55_FlixScape.xml, reusing each control's existing glow-center coordinates (same values already passed to the adjacent GlowPulse include).

Not touched: navigation, menu structure, widget content, spacing/ layout positions, or any packed texture art (corner radii on cards/ posters are baked into Textures.xbt PNGs and can't be reshaped without the TexturePacker tool, which isn't available in this environment).